### PR TITLE
refactored a bunch

### DIFF
--- a/lib/popover.js
+++ b/lib/popover.js
@@ -68,6 +68,8 @@ var Popover = (function (_React$Component) {
           if (_this2.state.isOpen == true) _this2.setState({ isOpen: false });
         });
       }
+      var topOffset = _react2['default'].findDOMNode(this.refs.toggleButton).offsetHeight + this.props.topOffset;
+      this.setState({ topOffset: topOffset });
     }
   }, {
     key: 'componentDidUpdate',
@@ -78,15 +80,24 @@ var Popover = (function (_React$Component) {
     key: 'calculateHeights',
     value: function calculateHeights() {
       if (!this.state.isOpen) return true;
-      this.buttonHeight = _react2['default'].findDOMNode(this.refs.toggleButton).offsetHeight;
-      this.buttonWidth = _react2['default'].findDOMNode(this.refs.toggleButton).offsetWidth;
+      var toggleButton = _react2['default'].findDOMNode(this.refs.toggleButton);
+      var popover = _react2['default'].findDOMNode(this.refs.popover);
 
-      this.popoverHeight = _react2['default'].findDOMNode(this.refs.popover).offsetHeight;
-      this.popoverWidth = _react2['default'].findDOMNode(this.refs.popover).offsetWidth;
+      var buttonHeight = toggleButton.offsetHeight;
+      var buttonWidth = toggleButton.offsetWidth;
+      var popoverHeight = popover.offsetHeight;
+      var popoverWidth = popover.offsetWidth;
+
+      var topOffset = this.calculateTopOffset();
+      var leftOffset = this.calculateLeftOffset();
 
       this.setState({
-        topOffset: this.calculateTopOffset(),
-        leftOffset: this.calculateLeftOffset()
+        buttonHeight: buttonHeight,
+        popoverHeight: popoverHeight,
+        buttonWidth: buttonWidth,
+        popoverWidth: popoverWidth,
+        topOffset: topOffset,
+        leftOffset: leftOffset
       });
     }
   }, {
@@ -96,16 +107,17 @@ var Popover = (function (_React$Component) {
 
       switch (this.props.position) {
         case 'top':
-          offset = '-' + (this.popoverHeight + this.props.topOffset) + 'px';
+          offset = '-' + (this.state.buttonHeight + this.props.topOffset);
           break;
         case 'bottom':
-          offset = this.buttonHeight + this.props.topOffset + 'px';
+          offset = this.state.buttonHeight + this.props.topOffset;
+          console.log(offset);
           break;
         case 'left':
-          offset = this.props.topOffset + 'px';
+          offset = this.props.topOffset;
           break;
         case 'right':
-          offset = this.props.topOffset + 'px';
+          offset = this.props.topOffset;
           break;
         default:
           offset = 0;
@@ -120,16 +132,16 @@ var Popover = (function (_React$Component) {
 
       switch (this.props.position) {
         case 'top':
-          offset = this.props.leftOffset + 'px';
+          offset = '-' + this.props.leftOffset;
           break;
         case 'bottom':
-          offset = this.props.leftOffset + 'px';
+          offset = this.props.leftOffset;
           break;
         case 'left':
-          offset = '-' + (this.popoverWidth + this.props.leftOffset) + 'px';
+          offset = '-' + (this.state.popoverWidth + this.props.leftOffset);
           break;
         case 'right':
-          offset = this.buttonWidth + this.props.leftOffset + 'px';
+          offset = this.state.buttonWidth + this.props.leftOffset;
           break;
         default:
           offset = 0;

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -65,7 +65,7 @@ var Popover = (function (_React$Component) {
       if (this.props.closeOnOuterClick !== false) {
         document.addEventListener('click', function (ev) {
           if (ev.target.dataset['popover']) return ev.stopImmediatePropagation();
-          _this2.setState({ isOpen: false });
+          if (_this2.state.isOpen == true) _this2.setState({ isOpen: false });
         });
       }
     }

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -1,18 +1,18 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require('react');
 
@@ -22,13 +22,9 @@ var Popover = (function (_React$Component) {
   _inherits(Popover, _React$Component);
 
   _createClass(Popover, null, [{
-    key: "defaultProps",
+    key: 'defaultProps',
     value: {
-      toggleButton: _react2["default"].createElement(
-        "button",
-        { className: "btn btn-lrg btn-success" },
-        "Toggle Menu"
-      ),
+      toggleButton: null,
       position: 'bottom',
       topOffset: 10,
       leftOffset: 0,
@@ -38,47 +34,55 @@ var Popover = (function (_React$Component) {
   }]);
 
   function Popover(props) {
+    var _this = this;
+
     _classCallCheck(this, Popover);
 
-    _get(Object.getPrototypeOf(Popover.prototype), "constructor", this).call(this, props);
+    _get(Object.getPrototypeOf(Popover.prototype), 'constructor', this).call(this, props);
+
+    this.toggle = function () {
+      _this.setState({ isOpen: !_this.state.isOpen });
+    };
 
     this.state = {
       topOffset: 0,
       leftOffset: 0,
-      isOpen: false
+      isOpen: props.isOpen || false
     };
   }
 
   _createClass(Popover, [{
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      var _this = this;
-
-      this.calculateHeights();
-
-      document.addEventListener('click', function (ev) {
-        ev.stopPropagation();
-        _this.handleClick(true, ev);
-      });
-
-      _react2["default"].findDOMNode(this.refs.popover).addEventListener('click', function (ev) {
-        if (_this.props.stopPropagation === false) return;
-        ev.stopPropagation();
-      });
-
-      _react2["default"].findDOMNode(this.refs.toggleButton).addEventListener('click', function (ev) {
-        ev.stopPropagation();
-        _this.handleClick(_this.props.isOpen, ev);
-      });
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(props) {
+      if (props.isOpen != this.state.isOpen) this.setState({ isOpen: props.isOpen });
     }
   }, {
-    key: "calculateHeights",
-    value: function calculateHeights() {
-      this.buttonHeight = _react2["default"].findDOMNode(this.refs.toggleButton).offsetHeight;
-      this.buttonWidth = _react2["default"].findDOMNode(this.refs.toggleButton).offsetWidth;
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var _this2 = this;
 
-      this.popoverHeight = _react2["default"].findDOMNode(this.refs.popover).offsetHeight;
-      this.popoverWidth = _react2["default"].findDOMNode(this.refs.popover).offsetWidth;
+      if (this.state.isOpen) this.calculateHeights();
+      if (this.props.closeOnOuterClick !== false) {
+        document.addEventListener('click', function (ev) {
+          if (ev.target.dataset['popover']) return ev.stopImmediatePropagation();
+          _this2.setState({ isOpen: false });
+        });
+      }
+    }
+  }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps, prevState) {
+      if (this.state.isOpen && this.state.isOpen != prevState.isOpen) this.calculateHeights();
+    }
+  }, {
+    key: 'calculateHeights',
+    value: function calculateHeights() {
+      if (!this.state.isOpen) return true;
+      this.buttonHeight = _react2['default'].findDOMNode(this.refs.toggleButton).offsetHeight;
+      this.buttonWidth = _react2['default'].findDOMNode(this.refs.toggleButton).offsetWidth;
+
+      this.popoverHeight = _react2['default'].findDOMNode(this.refs.popover).offsetHeight;
+      this.popoverWidth = _react2['default'].findDOMNode(this.refs.popover).offsetWidth;
 
       this.setState({
         topOffset: this.calculateTopOffset(),
@@ -86,27 +90,22 @@ var Popover = (function (_React$Component) {
       });
     }
   }, {
-    key: "handleClick",
-    value: function handleClick(value, ev) {
-      this.props.handleClick(value, ev);
-    }
-  }, {
-    key: "calculateTopOffset",
+    key: 'calculateTopOffset',
     value: function calculateTopOffset() {
       var offset = '0px';
 
       switch (this.props.position) {
         case 'top':
-          offset = "-" + (this.popoverHeight + this.props.topOffset) + "px";
+          offset = '-' + (this.popoverHeight + this.props.topOffset) + 'px';
           break;
         case 'bottom':
-          offset = this.buttonHeight + this.props.topOffset + "px";
+          offset = this.buttonHeight + this.props.topOffset + 'px';
           break;
         case 'left':
-          offset = this.props.topOffset + "px";
+          offset = this.props.topOffset + 'px';
           break;
         case 'right':
-          offset = this.props.topOffset + "px";
+          offset = this.props.topOffset + 'px';
           break;
         default:
           offset = 0;
@@ -115,22 +114,22 @@ var Popover = (function (_React$Component) {
       return offset;
     }
   }, {
-    key: "calculateLeftOffset",
+    key: 'calculateLeftOffset',
     value: function calculateLeftOffset() {
       var offset = '0px';
 
       switch (this.props.position) {
         case 'top':
-          offset = this.props.leftOffset + "px";
+          offset = this.props.leftOffset + 'px';
           break;
         case 'bottom':
-          offset = this.props.leftOffset + "px";
+          offset = this.props.leftOffset + 'px';
           break;
         case 'left':
-          offset = "-" + (this.popoverWidth + this.props.leftOffset) + "px";
+          offset = '-' + (this.popoverWidth + this.props.leftOffset) + 'px';
           break;
         case 'right':
-          offset = this.buttonWidth + this.props.leftOffset + "px";
+          offset = this.buttonWidth + this.props.leftOffset + 'px';
           break;
         default:
           offset = 0;
@@ -139,32 +138,45 @@ var Popover = (function (_React$Component) {
       return offset;
     }
   }, {
-    key: "render",
+    key: 'render',
     value: function render() {
-      var toggleButton = _react2["default"].cloneElement(this.props.toggleButton, {
-        ref: 'toggleButton'
-      });
+      if (this.props.toggleButton) {
+        var toggleButton = _react2['default'].cloneElement(this.props.toggleButton, {
+          ref: 'toggleButton',
+          'data-popover': true,
+          onClick: this.toggle
+        });
+      } else {
+        var toggleButton = _react2['default'].createElement('div', {
+          style: { display: 'none' },
+          onClick: this.toggle,
+          'data-popover': 'true',
+          ref: 'toggleButton'
+        });
+      }
 
-      var popoverClass = "popover-menu " + (this.props.className || '');
-      var contentClass = "popover-content " + this.props.position + " " + (this.props.isOpen ? 'show' : '');
       var contentStyles = { top: this.state.topOffset };
       contentStyles[this.props.horizontalJustify] = this.state.leftOffset;
 
-      return _react2["default"].createElement(
-        "div",
-        { className: popoverClass },
+      return _react2['default'].createElement(
+        'div',
+        { className: 'popover-menu ' + (this.props.className || '') },
         toggleButton,
-        _react2["default"].createElement(
-          "section",
-          { className: contentClass, style: contentStyles, ref: "popover" },
+        this.state.isOpen ? _react2['default'].createElement(
+          'section',
+          {
+            className: 'popover-content ' + this.props.position + ' show',
+            style: contentStyles,
+            onClick: this.toggle,
+            ref: 'popover' },
           this.props.children
-        )
+        ) : null
       );
     }
   }]);
 
   return Popover;
-})(_react2["default"].Component);
+})(_react2['default'].Component);
 
-exports["default"] = Popover;
-module.exports = exports["default"];
+exports['default'] = Popover;
+module.exports = exports['default'];

--- a/lib/popover.js
+++ b/lib/popover.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, '__esModule', {
   value: true
@@ -61,25 +61,23 @@ var Popover = (function (_React$Component) {
     value: function componentDidMount() {
       var _this2 = this;
 
-      if (this.state.isOpen) this.calculateHeights();
+      if (this.state.isOpen) this.calculateDimensions();
+
       if (this.props.closeOnOuterClick !== false) {
         document.addEventListener('click', function (ev) {
           if (ev.target.dataset['popover']) return ev.stopImmediatePropagation();
           if (_this2.state.isOpen == true) _this2.setState({ isOpen: false });
         });
       }
-      var topOffset = _react2['default'].findDOMNode(this.refs.toggleButton).offsetHeight + this.props.topOffset;
-      this.setState({ topOffset: topOffset });
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps, prevState) {
-      if (this.state.isOpen && this.state.isOpen != prevState.isOpen) this.calculateHeights();
+      if (this.state.isOpen && this.state.isOpen !== prevState.isOpen) this.calculateDimensions();
     }
   }, {
-    key: 'calculateHeights',
-    value: function calculateHeights() {
-      if (!this.state.isOpen) return true;
+    key: 'calculateDimensions',
+    value: function calculateDimensions() {
       var toggleButton = _react2['default'].findDOMNode(this.refs.toggleButton);
       var popover = _react2['default'].findDOMNode(this.refs.popover);
 
@@ -88,13 +86,11 @@ var Popover = (function (_React$Component) {
       var popoverHeight = popover.offsetHeight;
       var popoverWidth = popover.offsetWidth;
 
-      var topOffset = this.calculateTopOffset();
-      var leftOffset = this.calculateLeftOffset();
+      var topOffset = this.calculateTopOffset(popoverHeight, buttonHeight);
+      var leftOffset = this.calculateLeftOffset(popoverWidth, buttonWidth);
 
       this.setState({
-        buttonHeight: buttonHeight,
         popoverHeight: popoverHeight,
-        buttonWidth: buttonWidth,
         popoverWidth: popoverWidth,
         topOffset: topOffset,
         leftOffset: leftOffset
@@ -102,16 +98,15 @@ var Popover = (function (_React$Component) {
     }
   }, {
     key: 'calculateTopOffset',
-    value: function calculateTopOffset() {
+    value: function calculateTopOffset(popoverHeight, buttonHeight) {
       var offset = '0px';
 
       switch (this.props.position) {
         case 'top':
-          offset = '-' + (this.state.buttonHeight + this.props.topOffset);
+          offset = '-' + (popoverHeight + this.props.topOffset);
           break;
         case 'bottom':
-          offset = this.state.buttonHeight + this.props.topOffset;
-          console.log(offset);
+          offset = buttonHeight + this.props.topOffset;
           break;
         case 'left':
           offset = this.props.topOffset;
@@ -127,7 +122,7 @@ var Popover = (function (_React$Component) {
     }
   }, {
     key: 'calculateLeftOffset',
-    value: function calculateLeftOffset() {
+    value: function calculateLeftOffset(popoverWidth, buttonWidth) {
       var offset = '0px';
 
       switch (this.props.position) {
@@ -138,20 +133,20 @@ var Popover = (function (_React$Component) {
           offset = this.props.leftOffset;
           break;
         case 'left':
-          offset = '-' + (this.state.popoverWidth + this.props.leftOffset);
+          offset = '-' + (popoverWidth + this.props.leftOffset);
           break;
         case 'right':
-          offset = this.state.buttonWidth + this.props.leftOffset;
+          offset = buttonWidth + this.props.leftOffset;
           break;
         default:
           offset = 0;
       }
-
       return offset;
     }
   }, {
     key: 'render',
     value: function render() {
+      console.log(this.state);
       if (this.props.toggleButton) {
         var toggleButton = _react2['default'].cloneElement(this.props.toggleButton, {
           ref: 'toggleButton',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactable-popover",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "Popovers for React",
   "main": "./lib/popover.js",
   "scripts": {

--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -1,5 +1,3 @@
-"use strict";
-
 import React from 'react';
 
 export default class Popover extends React.Component {
@@ -26,27 +24,25 @@ export default class Popover extends React.Component {
   }
 
   componentDidMount() {
-    if(this.state.isOpen) this.calculateHeights();
+    if(this.state.isOpen) this.calculateDimensions();
+
     if(this.props.closeOnOuterClick !== false){
       document.addEventListener('click', (ev) => {
         if(ev.target.dataset['popover']) return ev.stopImmediatePropagation();
         if(this.state.isOpen == true) this.setState({isOpen: false})
       });
     }
-    let topOffset = React.findDOMNode(this.refs.toggleButton).offsetHeight + this.props.topOffset;
-    this.setState({topOffset})
   }
 
   componentDidUpdate(prevProps, prevState){
-    if(this.state.isOpen && this.state.isOpen != prevState.isOpen) this.calculateHeights();
+    if(this.state.isOpen && this.state.isOpen !== prevState.isOpen) this.calculateDimensions();
   }
 
   toggle = () => {
-    this.setState({isOpen: !this.state.isOpen})
+    this.setState({isOpen: !this.state.isOpen});
   }
 
-  calculateHeights() {
-    if(!this.state.isOpen) return true
+  calculateDimensions() {
     let toggleButton = React.findDOMNode(this.refs.toggleButton)
     let popover = React.findDOMNode(this.refs.popover)
 
@@ -55,28 +51,26 @@ export default class Popover extends React.Component {
     let popoverHeight = popover.offsetHeight;
     let popoverWidth = popover.offsetWidth;
 
-    let topOffset = this.calculateTopOffset()
-    let leftOffset = this.calculateLeftOffset()
+    let topOffset = this.calculateTopOffset(popoverHeight, buttonHeight);
+    let leftOffset = this.calculateLeftOffset(popoverWidth, buttonWidth);
 
     this.setState({
-      buttonHeight,
       popoverHeight,
-      buttonWidth,
       popoverWidth,
       topOffset,
       leftOffset
     });
   }
 
-  calculateTopOffset() {
+  calculateTopOffset(popoverHeight, buttonHeight) {
     let offset = '0px';
 
     switch(this.props.position) {
       case 'top':
-        offset = `-${this.state.buttonHeight + this.props.topOffset}`;
+        offset = `-${popoverHeight + this.props.topOffset}`;
         break;
       case 'bottom':
-        offset = this.state.buttonHeight + this.props.topOffset;
+        offset = buttonHeight + this.props.topOffset;
         break;
       case 'left':
         offset = this.props.topOffset;
@@ -91,7 +85,7 @@ export default class Popover extends React.Component {
     return offset;
   }
 
-  calculateLeftOffset() {
+  calculateLeftOffset(popoverWidth, buttonWidth) {
     let offset = '0px';
 
     switch(this.props.position) {
@@ -102,19 +96,19 @@ export default class Popover extends React.Component {
         offset = this.props.leftOffset;
         break;
       case 'left':
-        offset = `-${this.state.popoverWidth + this.props.leftOffset}`;
+        offset = `-${popoverWidth + this.props.leftOffset}`;
         break;
       case 'right':
-        offset = this.state.buttonWidth + this.props.leftOffset;
+        offset = buttonWidth + this.props.leftOffset;
         break;
       default:
         offset = 0;
     }
-
     return offset;
   }
 
   render() {
+    console.log(this.state);
     if(this.props.toggleButton){
       var toggleButton = React.cloneElement(this.props.toggleButton, {
         ref: 'toggleButton',

--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -33,6 +33,8 @@ export default class Popover extends React.Component {
         if(this.state.isOpen == true) this.setState({isOpen: false})
       });
     }
+    let topOffset = React.findDOMNode(this.refs.toggleButton).offsetHeight + this.props.topOffset;
+    this.setState({topOffset})
   }
 
   componentDidUpdate(prevProps, prevState){
@@ -45,15 +47,24 @@ export default class Popover extends React.Component {
 
   calculateHeights() {
     if(!this.state.isOpen) return true
-    this.buttonHeight = React.findDOMNode(this.refs.toggleButton).offsetHeight;
-    this.buttonWidth = React.findDOMNode(this.refs.toggleButton).offsetWidth;
+    let toggleButton = React.findDOMNode(this.refs.toggleButton)
+    let popover = React.findDOMNode(this.refs.popover)
 
-    this.popoverHeight = React.findDOMNode(this.refs.popover).offsetHeight;
-    this.popoverWidth = React.findDOMNode(this.refs.popover).offsetWidth;
+    let buttonHeight = toggleButton.offsetHeight;
+    let buttonWidth = toggleButton.offsetWidth;
+    let popoverHeight = popover.offsetHeight;
+    let popoverWidth = popover.offsetWidth;
+
+    let topOffset = this.calculateTopOffset()
+    let leftOffset = this.calculateLeftOffset()
 
     this.setState({
-      topOffset: this.calculateTopOffset(),
-      leftOffset: this.calculateLeftOffset()
+      buttonHeight,
+      popoverHeight,
+      buttonWidth,
+      popoverWidth,
+      topOffset,
+      leftOffset
     });
   }
 
@@ -62,16 +73,16 @@ export default class Popover extends React.Component {
 
     switch(this.props.position) {
       case 'top':
-        offset = `-${this.popoverHeight + this.props.topOffset}px`;
+        offset = `-${this.state.buttonHeight + this.props.topOffset}`;
         break;
       case 'bottom':
-        offset = `${this.buttonHeight + this.props.topOffset}px`;
+        offset = this.state.buttonHeight + this.props.topOffset;
         break;
       case 'left':
-        offset = `${this.props.topOffset}px`;
+        offset = this.props.topOffset;
         break;
       case 'right':
-        offset = `${this.props.topOffset}px`;
+        offset = this.props.topOffset;
         break;
       default:
         offset = 0;
@@ -85,16 +96,16 @@ export default class Popover extends React.Component {
 
     switch(this.props.position) {
       case 'top':
-        offset = `${this.props.leftOffset}px`;
+        offset = `-${this.props.leftOffset}`;
         break;
       case 'bottom':
-        offset = `${this.props.leftOffset}px`;
+        offset = this.props.leftOffset;
         break;
       case 'left':
-        offset = `-${this.popoverWidth + this.props.leftOffset}px`;
+        offset = `-${this.state.popoverWidth + this.props.leftOffset}`;
         break;
       case 'right':
-        offset = `${this.buttonWidth + this.props.leftOffset}px`;
+        offset = this.state.buttonWidth + this.props.leftOffset;
         break;
       default:
         offset = 0;

--- a/src/popover.jsx
+++ b/src/popover.jsx
@@ -30,7 +30,7 @@ export default class Popover extends React.Component {
     if(this.props.closeOnOuterClick !== false){
       document.addEventListener('click', (ev) => {
         if(ev.target.dataset['popover']) return ev.stopImmediatePropagation();
-        this.setState({isOpen: false})
+        if(this.state.isOpen == true) this.setState({isOpen: false})
       });
     }
   }


### PR DESCRIPTION
- isOpen is managed by the component itself, if you need to control this from the parent component, you must do this:

``` js
<img onClick={this.toggleOpen} data-popover="true"/>

<Popover isOpen={this.state.isOpen} />
```

The reason is, the global event listener will set the popover to close if you are clicking anywhere outside of the popover, unless if it sees the data-popover attribute. This isn't needed most of the time, that is in rare cases where you can't use a toggle button. Otherwise, this thing got simpler:

``` js
<Popover 
className='menu-popover dashboard'
position='bottom'
topOffset={60}
key='dashboards'>
```
- No more click handler or isOpen needed.
- Also added a new prop: `closeOnOuterClick={false}` the global event click handler won't be registered and the popover won't close on clicking outside
- now the popover is not rendered unless it's visible
